### PR TITLE
Need to check with number of operation if wait should still be called

### DIFF
--- a/DSGradientProgressView/DSGradientProgressView.swift
+++ b/DSGradientProgressView/DSGradientProgressView.swift
@@ -168,6 +168,9 @@ public class DSGradientProgressView: UIView, CAAnimationDelegate {
         }
         else {
             self.isHidden = true
+            if numberOfOperations > 0 {
+                wait()
+            }
         }
     }
     


### PR DESCRIPTION
## What/Why?
When a view is refreshed it stops the animation and does not continue anymore even though signal() was not yet called